### PR TITLE
Proposal: Makefile and setting version by tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dll
 *.so
 *.dylib
+pwcli
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+PREFIX?=/usr/local
+BINDIR?=$(_INSTDIR)/bin
+VERSION?=$(shell git tag | grep ^v | sort -V | tail -n 1)
+GOFLAGS?=-ldflags '-X main.VERSION=${VERSION}'
+
+pwcli: cli.go go.mod go.sum
+	@echo
+	@echo Building pwcli. This may take a minute or two.
+	@echo
+	go build $(GOFLAGS) -o $@
+	@echo
+	@echo ...Done\!
+
+.PHONY: clean
+clean:
+	@echo
+	@echo Cleaning...
+	@echo
+	go clean
+	@echo
+	@echo ...Done\!
+
+.PHONY: update
+update:
+	@echo
+	@echo Updating from upstream repository...
+	@echo
+	git pull --rebase origin master
+	@echo
+	@echo ...Done\!
+
+.PHONY: install
+install:
+	@echo
+	@echo Installing pwcli...
+	@echo
+	install -m755 pwcli $(BINDIR)
+	@echo
+	@echo ...Done\!
+
+.PHONY: uninstall
+uninstall:
+	@echo
+	@echo Uninstalling pwcli...
+	@echo
+	rm -f $(BINDIR)/pwcli
+	@echo
+	@echo ...Done\!

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr/local
-BINDIR?=$(_INSTDIR)/bin
+BINDIR?=$(PREFIX)/bin
 VERSION?=$(shell git tag | grep ^v | sort -V | tail -n 1)
 GOFLAGS?=-ldflags '-X main.VERSION=${VERSION}'
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,41 @@
-# PostWoman CLI   [![Build Status](https://travis-ci.com/athul/pwcli.svg?token=udLtq6DyJs4Gxpze9nqX&branch=master)](https://travis-ci.com/athul/pwcli)[![Postwoman](https://img.shields.io/badge/Made_for-Postwoman-hex_color_code?logo=Postwoman)](https://postwoman.io) [![Go Report Card](https://goreportcard.com/badge/github.com/athul/pwcli)](https://goreportcard.com/report/github.com/athul/pwcli)
+# PostWoman CLI [![Build Status](https://travis-ci.com/athul/pwcli.svg?token=udLtq6DyJs4Gxpze9nqX&branch=master)](https://travis-ci.com/athul/pwcli) [![Postwoman](https://img.shields.io/badge/Made_for-Postwoman-hex_color_code?logo=Postwoman)](https://postwoman.io) [![Go Report Card](https://goreportcard.com/badge/github.com/athul/pwcli)](https://goreportcard.com/report/github.com/athul/pwcli)
+
 Use Postwoman's CLI direct from your terminal.
 
 # Installation
+
 ### From Script
+
 ```bash
 $ sh -c "$(curl -sL https://git.io/getpwcli)"
 ```
+
 ### From Source
+
 - Clone the repo
-- Build using `go build`
-- Move Binary to `/usr/local/bin/`
+
+```
+$ git clone https://github.com/athul/pwcli
+```
+
+- Build and install
+
+```
+$ make
+
+$ sudo make install
+```
+
 ### From Binary
-- You can find the Binaries in Gzipped form from the [Releases](https://github.com/athul/pwcli/releases) page      
-**Supports**
+
+- You can find the Binaries in Gzipped form from the [Releases](https://github.com/athul/pwcli/releases) page  
+  **Supports**
 - Linux(x64,x86)
 - Mac(x64)
 - Windows(x64,x86)
 
 ### Homebrew
+
 Install by `brew install athul/tap/pwcli`
 
 > **IMPORTANT: Not tested on Windows, please leave your feedback/bugs in the Issues section**
@@ -26,22 +44,21 @@ Install by `brew install athul/tap/pwcli`
 
 Putting Simply: **Just pass the URL to the request method**
 
-
 - GET : `pwcli get <url> -t/--token <token> -u <username for basic auth> -p <password for basic auth>`
 - POST: `pwcli post <url> < -t/-u/-p > -c/--content type <content type> -b/--body <body>`
 - PATCH: `pwcli patch <url> < -t/-u/-p > -c/--content type <content type> -b/--body <body>`
 - PUT : `pwcli put <url> < -t/-u/-p > -c/--content type <content type> -b/--body <body>`
 - DELETE: `pwcli delete <url> < -t/-u/-p > -c/--content type <content type> -b/--body <body>`
 
-**Content Types can be of**   
-`html`   :   `text/html`  
-`js`     :   `application/json`,   
-`xml`    :   `application/xml`   
-`plain`  :   `text/plain`,   
-
+**Content Types can be of**  
+`html` : `text/html`  
+`js` : `application/json`,  
+`xml` : `application/xml`  
+`plain` : `text/plain`,
 
 #### Extra
-**SEND**: This can be used to test multiple endpoints from the `postwoman-collection.json` file. The output will only be the `statuscode`.       
-RUN: `pwcli send <PATH to postwoman collection.json>`      
-OUTPUT: 
+
+**SEND**: This can be used to test multiple endpoints from the `postwoman-collection.json` file. The output will only be the `statuscode`.  
+RUN: `pwcli send <PATH to postwoman collection.json>`  
+OUTPUT:
 ![](/assets/send.png)

--- a/cli.go
+++ b/cli.go
@@ -10,10 +10,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+// VERSION is set by `make` during the build to the most recent tag
+var VERSION = "v0.0.4"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = color.HiGreenString("Postwoman CLI")
-	app.Version = color.HiRedString("0.0.2")
+	app.Version = color.HiRedString(VERSION)
 	app.Usage = color.HiYellowString("Test API endpoints without the hassle")
 	app.Description = color.HiBlueString("Made with <3 by Postwoman Team")
 


### PR DESCRIPTION
I added a short `Makefile` that makes it a bit easier for someone to quickly build/install/update using `make`. The version is set in `cli.go` during buildtime to the highest version tag by building this way.

When I added the `make` instructions to `README.md` it appears VSCode autoformatted, so apologies for the whitespace. But, I figured it was harmless.

I don't know if this is a change you would want, but I figured why not propose it? If you do want this, feel free to merge it. And if not, feel free to close the PR instead (I won't be offended).